### PR TITLE
centos7-minimal.cfg: add commented option for http install

### DIFF
--- a/centos7-minimal.cfg
+++ b/centos7-minimal.cfg
@@ -10,8 +10,9 @@ text
 auth --enableshadow --passalgo=sha512
 keyboard --vckeymap=us --xlayouts='us'
 
-# Installation files source (CentOS-7.0-1406-x86_64-Minimal.iso)
-cdrom
+# Installation files source
+cdrom  # install straight from booted disk
+#url --url http://mirror.centos.org/centos/7/os/x86_64/  # http install
 
 # Using only primary disk, ignoring others
 ignoredisk --only-use=sda
@@ -44,7 +45,7 @@ autopart --type=lvm
 # Eject cdrom and reboot
 reboot --eject
 
-# Installing only packages for minimal install 
+# Installing only packages for minimal install
 %packages
 @Core
 chrony


### PR DESCRIPTION
(this is actually a backport of how I'm doing it for CentOS 8, where the "boot" ISO *needs* http install, and the "dvd" ISO is *huge*)